### PR TITLE
Socket fixes

### DIFF
--- a/Sources/HTTPResponseWriter.swift
+++ b/Sources/HTTPResponseWriter.swift
@@ -41,9 +41,15 @@ public class HTTPResponseWriter {
     }
 
     public func write(bytes: UnsafePointer<Int8>) throws {
+#if os(Linux)
+        let flags = Int32(MSG_NOSIGNAL)
+#else
+        let flags = Int32(0)
+#endif
+
         var rest = Int(strlen(bytes))
         while rest > 0 {
-            let sent = send(socket, bytes, rest, 0)
+            let sent = send(socket, bytes, rest, flags)
             if sent < 0 {
                 throw WriterError.GenericError(error: errno)
             }

--- a/Sources/HTTPServer.swift
+++ b/Sources/HTTPServer.swift
@@ -56,6 +56,7 @@ public struct HTTPServer {
             }
             let client = accept(socket.underlying, nil, nil)
             defer {
+                shutdown(client, Int32(SHUT_RDWR))
                 close(client)
             }
             do {

--- a/Sources/HTTPServer.swift
+++ b/Sources/HTTPServer.swift
@@ -38,6 +38,12 @@ public struct HTTPServer {
     public init?(socket: Socket, addr: SocketAddress) {
         self.socket = socket
         self.address = addr
+
+        socket.setOption(SO_REUSEADDR, value: 1)
+#if !os(Linux)
+        socket.setOption(SO_NOSIGPIPE, value: 1)
+#endif
+
         if !socket.bindAddress(&address.underlying, length: socklen_t(UInt8(sizeof(sockaddr_in)))) {
             return nil
         }

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -50,6 +50,10 @@ public struct Socket {
         return bind(underlying, UnsafeMutablePointer<sockaddr>(address), length) == 0
     }
 
+    public func setOption(option: Int32, value: Int32) {
+        var val = value
+        setsockopt(underlying, SOL_SOCKET, option, &val, socklen_t(sizeof(Int32)))
+    }
 }
 
 public struct SocketAddress {


### PR DESCRIPTION
This fixes a few sockets-related issues that I encountered while trying to deploy a Swiftra app.
- Prevent crashes due to receiving SIGPIPE when writing to a connection that was closed by the other end
- Try harder to ensure that all bytes get sent before closing the socket
